### PR TITLE
Nuget/pack

### DIFF
--- a/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.csproj
+++ b/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.DependencyInjection.SolrNet</AssemblyName>
     <RootNamespace>SolrNet</RootNamespace>
+    <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Version>0.7.1</Version>
     <Authors>Mauricio Scheffer and contributors</Authors>

--- a/SolrNet/SolrNet.nuspec
+++ b/SolrNet/SolrNet.nuspec
@@ -26,11 +26,11 @@
 
   </metadata>
   <files>
-    <file src="lib\net46\SolrNet.dll" target="lib\net46\SolrNet.dll" />
-    <file src="lib\net46\SolrNet.xml" target="lib\net46\SolrNet.xml" />
-    <file src="lib\net46\SolrNet.pdb" target="lib\net46\SolrNet.pdb" />
-    <file src="lib\netstandard2.0\SolrNet.dll" target="lib\netstandard2.0\SolrNet.dll" />
-    <file src="lib\netstandard2.0\SolrNet.xml" target="lib\netstandard2.0\SolrNet.xml" />
-    <file src="lib\netstandard2.0\SolrNet.pdb" target="lib\netstandard2.0\SolrNet.pdb" />
+    <file src="bin\release\net46\SolrNet.dll" target="lib\net46\SolrNet.dll" />
+    <file src="bin\release\net46\SolrNet.xml" target="lib\net46\SolrNet.xml" />
+    <file src="bin\release\net46\SolrNet.pdb" target="lib\net46\SolrNet.pdb" />
+    <file src="bin\release\netstandard2.0\SolrNet.dll" target="lib\netstandard2.0\SolrNet.dll" />
+    <file src="bin\release\netstandard2.0\SolrNet.xml" target="lib\netstandard2.0\SolrNet.xml" />
+    <file src="bin\release\netstandard2.0\SolrNet.pdb" target="lib\netstandard2.0\SolrNet.pdb" />
   </files>
 </package>


### PR DESCRIPTION
fix _dotnet pack_ not respecting nuspec for netstandard-assemblies
Also modified solrnet.nuspec, as my local _build_ and _pack_ did not compile any files in the referenced location and therfore couldn´t be found during package generation (lib/net46, etc.)